### PR TITLE
fix: add macfuse match, new `MointPoint.release_mount()`

### DIFF
--- a/lua/sshfs/init.lua
+++ b/lua/sshfs/init.lua
@@ -27,7 +27,7 @@ function App.setup(user_opts)
 				local all_connections = vim.list_extend({}, MountPoint.list_active())
 
 				for _, connection in ipairs(all_connections) do
-					Session.disconnect_from(connection)
+					Session.disconnect_from(connection, true)
 				end
 			end,
 			desc = "Cleanup SSH mounts on exit",

--- a/lua/sshfs/session.lua
+++ b/lua/sshfs/session.lua
@@ -92,6 +92,12 @@ function Session.disconnect_from(connection, silent)
 		end
 	end
 
+	-- Release buffers and LSPs associated with mount point
+	local safe_to_unmount = MountPoint.release_mount(connection.mount_path, silent)
+	if not safe_to_unmount then
+		return false
+	end
+
 	-- Unmount the filesystem
 	local success = MountPoint.unmount(connection.mount_path)
 


### PR DESCRIPTION
Thanks for making this! Ran into a few things that didn't work in macOS for me -- this PR resolves them. 

This PR includes (1) quickfixes for the mounted host to be detectable and auto-unmounted by sshfs.nvim in macOS and (2) some accompanying cleanup logic for releasing buffers associated with the mount before unmounting.

## (1) MacOS Quickfixes

Currently on my MacOS environment (M4 Macbook Pro, Sequoia 15.6.1, macFUSE and SSHFS for macFUSE installed as per README) running `mount` and inspecting the host left mounted by sshfs shows the following for the mount options: `(macfuse, nodev, nosuid, synchronous, mounted by andrewcchu)`. This will not get picked up by the [match on `sshfs` on line 45 of `mount_point.lua`](https://github.com/uhs-robert/sshfs.nvim/blob/main/lua/sshfs/lib/mount_point.lua#L45) and thus will not be added to the returned table. As a result, no sshfs.nvim commands can be run after opening a remote file; you instead get the warning: `Not connected to any remote host`.

Changing line 45 to also include a match for `macfuse` resolves this problem, and allows commands to be run.

## (2) `MountPoint.release_mount()`

The existing methods for unmounting on macOS appear to fail because lingering processes still hold the handle for the mounted host. `umount -l` typically gets around this, but it is not available on macOS. One option is to just add the `force` option to `diskutil unmount`, but this isn't the most safe. This function adds logic to manually release anything still holding the handle, and allows the macOS unmount commands to run successfully. 

Additionally, this adds a bit of functionality to throw an error notification if either of the `:SSHDisconnect` or `:SSHDisconnectAll` commands are executed if there are unsaved changes in the buffer (basically the same as shown if `:q` is used with unsaved changes), and stop the unmounting logic. 

## Minor other

Pass `true` for `silent` to `Session.disconnect_from` in `init.lua` for the `:q` exit handler, since there will not be a window to draw to (prevents error).

---

Hopefully this is useful, happy to discuss any changes/modifications. Thanks again and happy holidays!